### PR TITLE
Fix bug with `cd` upon first usage, prior to running `ls`

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -34,12 +34,12 @@ BreakStringLiterals: false
 ColumnLimit: 100
 Cpp11BracedListStyle: false
 EmptyLineBeforeAccessModifier: LogicalBlock
-IndentCaseBlocks: true
+IndentCaseBlocks: false
 IndentCaseLabels: true
 IndentWidth: 4
 NamespaceIndentation: All
 PointerAlignment: Left
-SortIncludes: true
+SortIncludes: CaseSensitive
 SpaceBeforeCaseColon: false
 TabWidth: 4
 UseTab: Always

--- a/source/arch/i386/kernel/shell.cpp
+++ b/source/arch/i386/kernel/shell.cpp
@@ -220,7 +220,7 @@ void Shell::input(char c)
 				}
 				g_commandBuffer[g_inputCursor] = '\0';
 
-				CMD::processCmd(g_commandBuffer);
+				CMD::run(g_commandBuffer);
 				memset(g_commandBuffer, 0, size);
 				clearInput();
 				return;

--- a/source/processes/cmd.h
+++ b/source/processes/cmd.h
@@ -16,7 +16,7 @@ namespace CMD
 	};
 
 	void init();
-	void processCmd(const char* cmd);
+	void run(const char* cmd);
 	bool parseCmdArgs(const char* cmd, char* args[], int32_t* argCount);
 	bool isValidExecutable(const char* exe);
 	bool isRootDir(const char* path);


### PR DESCRIPTION
**Reproduction steps:**
1. Enter `cd home`.
2. Enter `ls`. The `.` and `..` directories are missing.
3. Enter `ls` again. It will produce `Unknown command ''`.

There's some kind of memory corruption. If you run `ls` prior to running any of the above steps, the commands work as expected.